### PR TITLE
magento2.4対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.4-apache
 
 RUN apt-get update \
   && apt-get install -y \
@@ -8,42 +8,41 @@ RUN apt-get update \
     libxml2-dev \
     libxslt1-dev \
     libjpeg62-turbo-dev \
-    libmcrypt-dev \
+    libzip-dev \
+    libonig-dev \
     libpng-dev \
     libmagickwand-dev \
-    phantomjs \
-    zsh \
     default-mysql-client \
     vim \
     wget \
     git \
     nodejs \
     npm \
+    unzip \
   && docker-php-ext-configure \
-    gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
   && docker-php-ext-install \
     dom \
     gd \
     intl \
-    mbstring \
-    mcrypt \
     bcmath \
     pdo_mysql \
     opcache \
     xsl \
     zip \
     soap \
+    sockets \
   && a2enmod rewrite \
-  && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1 \
-  && pecl install xdebug-2.9.8 && docker-php-ext-enable xdebug \
+  && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+  && curl https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+  && pecl install xdebug && docker-php-ext-enable xdebug \
   && pecl install imagick && docker-php-ext-enable imagick \
   && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && echo "xdebug.remote_port=9000" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && echo "xdebug.remote_connect_back=0" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-  && echo "xdebug.remote_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+  && echo "xdebug.remote_host=10.254.254.254" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && echo "xdebug.max_nesting_level=1000" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-  && echo "xdebug.remote_autostart=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && chmod 666 /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini \
   && sed -ri 's/^(memory_limit = )[0-9]+(M|G)$/memory_limit = 2G/' /usr/local/etc/php/php.ini \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update \
   && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && echo "xdebug.remote_port=9000" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && echo "xdebug.remote_connect_back=0" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-  && echo "xdebug.remote_host=10.254.254.254" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+  && echo "xdebug.remote_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && echo "xdebug.max_nesting_level=1000" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
   && chmod 666 /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: ./
     image: magento2-web
     ports:
-      - "8888:80"
+      - "32770:80"
     links:
       - db
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: ./
     image: magento2-web
     ports:
-      - "32770:80"
+      - "8888:80"
     links:
       - db
     volumes:
@@ -15,7 +15,7 @@ services:
       - magento-network
 
   db:
-    image: mysql:5.7
+    image: mysql:8.0
     platform: linux/amd64
     ports:
       - "32769:3306"
@@ -48,6 +48,16 @@ services:
       - 8025:8025
     networks:
       - magento-network
+
+  elasticsearch:
+        image: elasticsearch:7.9.0
+        ports:
+            - "9200:9200"
+            - "9300:9300"
+        environment:
+            discovery.type: single-node
+        networks:
+            - magento-network
 
 volumes:
   magento-sync:


### PR DESCRIPTION
# 内容
Magento2.4系に対応したDockerの作成
チケット：#14732
タグ：2.4

## 変更概要
### Dockerfile
magento2.4要件への対応
・php 7.4
・composer 2系 

M1で入らなかったものの削除
・phantomjs等

### docker-compose.yml
・mysql image v8.0へ
・elasticsearchの導入